### PR TITLE
Enhance CI workflow with security permissions and checkout update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches: [ '*' ]
 
+# Restrict default permissions for security
+permissions:
+  contents: read
+
 jobs:
   test_and_build:
     runs-on: ${{matrix.os}}
@@ -21,7 +25,9 @@ jobs:
           - os: ubuntu-22.04-arm
             arch: 'arm64'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Set up Ruby 3.1
         uses: ruby/setup-ruby@90be1154f987f4dc0fe0dd0feedac9e473aa4ba8 # v1
         with:


### PR DESCRIPTION
This pull request makes security and dependency improvements to the GitHub Actions CI workflow by restricting default permissions and updating the checkout action. The main changes are:

Security improvements:
* Restricted default permissions for GitHub Actions workflows to read-only for repository contents, reducing the risk of accidental or malicious modifications.

Dependency updates:
* Updated the `actions/checkout` action from version 3 to version 4 and set `persist-credentials: false` to further limit token exposure during CI runs.


CC @IvanTakarlikov-st @st-misha 